### PR TITLE
add main property to support newer versions of npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "underscore",
     "string"
   ],
+  "main": "./lib/underscore.string",
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
Also required for node 0.4, otherwise "require('underscore.string')" doesn't work
