### PR TITLE
Updated sprintf, added vsprintf

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -355,6 +355,11 @@
             return str_format;
         }()),
 
+        vsprintf: function(fmt, argv) {
+            argv.unshift(fmt);
+            return _.sprintf.apply(null, argv);
+        },
+
         toNumber: function(str, decimals) {
            return parseNumber(parseNumber(str).toFixed(parseNumber(decimals)));
          },

--- a/test/strings.js
+++ b/test/strings.js
@@ -93,6 +93,18 @@ $(document).ready(function() {
     equals(_.sprintf("%(args[0].id)d - %(args[1].name)s", {args: [{id: 824}, {name: "Hello World"}]}), "824 - Hello World", 'Named replacements with arrays work');
   });
 
+  test("Strings: vsprintf", function() {
+    // Should be very tested function already.  Thanks to
+    // http://www.diveintojavascript.com/projects/sprintf-for-javascript
+    equals(_.vsprintf("Hello %s", ["me"]), "Hello me", 'basic');
+    equals(_("Hello %s").vsprintf(["me"]), "Hello me", 'object');
+    equals(_("hello %s").chain().vsprintf(["me"]).capitalize().value(), "Hello me", 'Chaining works');
+    equals(_.vsprintf("%.1f", [1.22222]), "1.2", 'round');
+    equals(_.vsprintf("%.1f", [1.17]), "1.2", 'round 2');
+    equals(_.vsprintf("%(id)d - %(name)s", [{id: 824, name: "Hello World"}]), "824 - Hello World", 'Named replacements work');
+    equals(_.vsprintf("%(args[0].id)d - %(args[1].name)s", [{args: [{id: 824}, {name: "Hello World"}]}]), "824 - Hello World", 'Named replacements with arrays work');
+  });
+
   test("Strings: startsWith", function() {
     ok(_("foobar").startsWith("foo"), 'foobar starts with foo');
     ok(!_("oobar").startsWith("foo"), 'oobar does not start with foo');


### PR DESCRIPTION
I was looking to use some named replacements with sprintf and noticed that the underscore.string version didn't support them, so I upgraded sprintf to use Alexandru Marasteanu's latest code. His current release is a beta, which may be of some concern, but it's working for me at least. I've also included vsprintf for the sake of completeness.

Cheers.
