### PR TITLE
Throw actual exceptions, not strings, to webkit at least displays a sourc

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -248,10 +248,10 @@
                 }
                 else if (m = /^\x25(?:(\d+)\$)?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-fosuxX])/.exec(f)) {
                     if (((a = arguments[m[1] || i++]) == null) || (a == undefined)) {
-                        throw('Too few arguments.');
+                        throw new Error('Too few arguments.');
                     }
                     if (/[^s]/.test(m[7]) && (typeof(a) != 'number')) {
-                        throw('Expecting number but found ' + typeof(a));
+                        throw new TypeError('Expecting number but found ' + typeof(a));
                     }
                     switch (m[7]) {
                         case 'b': a = a.toString(2); break;
@@ -272,7 +272,7 @@
                     o.push(s + (m[4] ? a + p : p + a));
                 }
                 else {
-                    throw('Huh ?!');
+                    throw new Error('Universe error: 17');
                 }
                 f = f.substring(m[0].length);
             }


### PR DESCRIPTION
Throw actual exceptions, not strings, to webkit at least displays a source link for the error instead of just printing the string in its console without any hint as to where it came from.
