### PR TITLE
Use as a common js module if module && module.exports regardless of 'window' presence

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -454,7 +454,7 @@
   _s.rjust  = _s.rpad;
 
   // CommonJS module is defined
-  if (typeof window === 'undefined' && typeof module !== 'undefined') {
+  if (typeof module !== 'undefined' && module.exports) {
     // Export module
     module.exports = _s;
 


### PR DESCRIPTION
Following underscore.js convention, use common js module if module && module.exports, and leave out window check for client/server uniformity.

Ran into this issue using underscore.string with Ender in the browser. I want underscore.string to export as a module, but it won't because window is defined.

Just removing the window check breaks the tests, because module is actually defined by qunit. I looked at what underscore.js itself does, and it checks for both module and module.exports. qunit's module does not have an exports property, so the tests pass with that check in place, and it seems like the right check to make regardless per the common js spec.
