### PR TITLE
Fixes a closure_compiler warning for a body-less for block.

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -22,7 +22,7 @@
   var parseNumber = function(source) { return source * 1 || 0; };
 
   var strRepeat = function(i, m) {
-    for (var o = []; m > 0; o[--m] = i);
+    for (var o = []; m > 0; o[--m] = i) {}
     return o.join('');
   };
 


### PR DESCRIPTION
WARNING - If this if/for/while really shouldnt have a body, use {}
   for (var o = []; m > 0; o[--m] = i);
