### PR TITLE
add support for CommonJS implementations that do not support modules.expo

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -444,9 +444,12 @@
   _s.rjust  = _s.rpad;
 
   // CommonJS module is defined
-  if (typeof module !== 'undefined' && module.exports) {
-    // Export module
-    module.exports = _s;
+  if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      // Export module
+      module.exports = _s;
+    }
+    exports._s = _s
 
   // Integrate with Underscore.js
   } else if (typeof root._ !== 'undefined') {


### PR DESCRIPTION
Add support for CommonJS implementations that do not support modules.exports.

Same as https://github.com/documentcloud/underscore/pull/335
