### PR TITLE
Throw actual errors instead of strings

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -73,7 +73,7 @@
             arg = argv[cursor];
             for (k = 0; k < match[2].length; k++) {
               if (!arg.hasOwnProperty(match[2][k])) {
-                throw(sprintf('[_.sprintf] property "%s" does not exist', match[2][k]));
+                throw new Error(sprintf('[_.sprintf] property "%s" does not exist', match[2][k]));
               }
               arg = arg[match[2][k]];
             }
@@ -85,7 +85,7 @@
           }
 
           if (/[^s]/.test(match[8]) && (get_type(arg) != 'number')) {
-            throw(sprintf('[_.sprintf] expecting number but found %s', get_type(arg)));
+            throw new Error(sprintf('[_.sprintf] expecting number but found %s', get_type(arg)));
           }
           switch (match[8]) {
             case 'b': arg = arg.toString(2); break;


### PR DESCRIPTION
...context (line numbers, or even full tracebacks) in the console, which makes debugging incorrect patterns or arguments much easier.
