### PR TITLE
Like underscore, optionally call AMD define() to register module

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -463,6 +463,12 @@
     }
     exports._s = _s;
 
+  } else if (typeof define === 'function' && define.amd) {
+    // Register as a named module with AMD.
+    define('underscore.string', function() {
+      return _s;
+    });
+
   // Integrate with Underscore.js
   } else if (typeof root._ !== 'undefined') {
     // root._.mixin(_s);


### PR DESCRIPTION
Adaptation of James Burke's patch to underscore: documentcloud/underscore#338
