### PR TITLE
Convert all error throwing to throw actual Error objects 

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -134,12 +134,12 @@
                   field_list.push(field_match[1]);
                 }
                 else {
-                  throw('[_.sprintf] huh?');
+                  throw new Error('[_.sprintf] huh?');
                 }
               }
             }
             else {
-              throw('[_.sprintf] huh?');
+              throw new Error('[_.sprintf] huh?');
             }
             match[2] = field_list;
           }
@@ -147,12 +147,12 @@
             arg_names |= 2;
           }
           if (arg_names === 3) {
-            throw('[_.sprintf] mixing positional and named placeholders is not (yet) supported');
+            throw new Error('[_.sprintf] mixing positional and named placeholders is not (yet) supported');
           }
           parse_tree.push(match);
         }
         else {
-          throw('[_.sprintf] huh?');
+          throw new Error('[_.sprintf] huh?');
         }
         _fmt = _fmt.substring(match[0].length);
       }


### PR DESCRIPTION
Otherwise, traceback is missing and it is much harder to find out which piece of code passed the wrong argumnets to _.sprintf
