### PR TITLE
If present “dependencies” should be a hash not an array.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "engines": {
     "node": "*"
   },
-  "dependencies": [],
+  "dependencies": {
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/epeli/underscore.string.git"


### PR DESCRIPTION
npm puts out a warning when “dependencies” is an array and not a hash of key:value pairs.
