### PR TITLE
Dasherize - Fix for multiple dashes

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -287,7 +287,7 @@
     },
 
     dasherize: function(str){
-      return _s.trim(str).replace(/[\W_]+/g, '-').replace(/([A-Z])/g, '-$1').replace(/-+/, '-').toLowerCase();
+      return _s.trim(str).replace(/[\W_]+/g, '-').replace(/([A-Z])/g, '-$1').replace(/-+/g, '-').toLowerCase();
     },
 
     humanize: function(str){

--- a/test/strings.js
+++ b/test/strings.js
@@ -196,6 +196,9 @@ $(document).ready(function() {
     equals(_('the_dasherize_string_method').dasherize(), 'the-dasherize-string-method');
     equals(_('TheDasherizeStringMethod').dasherize(), '-the-dasherize-string-method');
     equals(_('thisIsATest').dasherize(), 'this-is-a-test');
+    equals(_('this Is A Test').dasherize(), 'this-is-a-test');
+    equals(_('thisIsATest123').dasherize(), 'this-is-a-test123');
+    equals(_('123thisIsATest').dasherize(), '123this-is-a-test');
     equals(_('the dasherize string method').dasherize(), 'the-dasherize-string-method');
     equals(_('the  dasherize string method  ').dasherize(), 'the-dasherize-string-method');
     equals(_(123).dasherize(), '123');


### PR DESCRIPTION
Hi,

The recent fix for issue #89 ended up breaking a separate test case for me that also wasn't covered by the underscore.string.js test cases.  Basically, doing this:

`_('this Is A Test').dasherize()`

would result in:

`this-is--a--test` instead of `this-is-a-test`

I've committed a change that fixes that and a test case that covers that.  Additionally, there are a couple more test cases added.
