### PR TITLE
Use String.prototype.trim[Left|Right] when available

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -12,6 +12,8 @@
   // Defining helper functions.
 
   var nativeTrim = String.prototype.trim;
+  var nativeTrimRight = String.prototype.trimRight;
+  var nativeTrimLeft = String.prototype.trimLeft;
 
   var parseNumber = function(source) { return source * 1 || 0; };
 
@@ -297,11 +299,17 @@
     },
 
     ltrim: function(str, characters){
+      if (!characters && nativeTrimLeft) {
+        return nativeTrimLeft.call(str);
+      }
       characters = defaultToWhiteSpace(characters);
       return (''+str).replace(new RegExp('\^' + characters + '+', 'g'), '');
     },
 
     rtrim: function(str, characters){
+      if (!characters && nativeTrimRight) {
+        return nativeTrimRight.call(str);
+      }
       characters = defaultToWhiteSpace(characters);
       return (''+str).replace(new RegExp(characters + '+$', 'g'), '');
     },


### PR DESCRIPTION
Available in:
- Firefox latest
- Chrome latest
- Safari latest
