### PR TITLE
Handle numeric character references in unescapeHTML

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -209,8 +209,27 @@
     },
 
     unescapeHTML: function(str) {
-      return (''+str).replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-                            .replace(/&quot;/g, '"').replace(/&apos;/g, "'").replace(/&amp;/g, '&');
+      return (''+str).replace(/&([^;]+);/g, function(matched, p1) {
+        switch (p1) {
+          case 'lt': return '<';
+          case 'gt': return '>';
+          case 'quot': return '"';
+          case 'apos': return "'";
+          case 'amp': return '&';
+        }
+
+        var hexNumericEntity = p1.match(/^#x([0-9a-fA-F]+)$/);
+        if (hexNumericEntity) {
+          return String.fromCharCode(parseInt(hexNumericEntity[1], 16));
+        }
+
+        var numericEntity = p1.match(/^#(\d+)$/);
+        if (numericEntity) {
+          return String.fromCharCode(parseInt(numericEntity[1], 10));
+        }
+
+        return matched;
+      });
     },
 
     escapeRegExp: function(str){

--- a/test/strings.js
+++ b/test/strings.js
@@ -266,6 +266,15 @@ $(document).ready(function() {
     equals(_('&lt;div&gt;Blah &amp; &quot;blah&quot; &amp; &apos;blah&apos;&lt;/div&gt;').unescapeHTML(),
              '<div>Blah & "blah" & \'blah\'</div>');
     equals(_('&amp;lt;').unescapeHTML(), '&lt;');
+    equals(_('&#39;').unescapeHTML(), "'");
+    equals(_('&#0039;').unescapeHTML(), "'");
+    equals(_('&#x4a;').unescapeHTML(), "J");
+    equals(_('&#x04A;').unescapeHTML(), "J");
+    equals(_('&#X4A;').unescapeHTML(), "&#X4A;");
+    equals(_('&_#39;').unescapeHTML(), "&_#39;");
+    equals(_('&#39_;').unescapeHTML(), "&#39_;");
+    equals(_('&amp;#38;').unescapeHTML(), "&#38;");
+    equals(_('&#38;amp;').unescapeHTML(), "&amp;");
     equals(_(5).unescapeHTML(), '5');
     // equals(_(undefined).unescapeHTML(), '');
   });


### PR DESCRIPTION
I was using `unescapeHTML` on some text, and I was disappointed to see that [numeric character references](http://en.wikipedia.org/wiki/Numeric_character_reference) -- particularly `&#39;` -- were not being unescaped.  This commit unescapes decimal and hexadecimal NCRs in all the legal variations I was able to find (both uppercase and lowercase hexadecimal digits, decimal digits, leading zeros in both cases).
