### PR TITLE
Add swapCase function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -110,6 +110,15 @@ _.chars('Hello')
 => ['H','e','l','l','o']
 ```
 
+**swapCase** _.swapCase(str)
+
+Returns a copy of the string in which all the case-based characters have had their case swapped.
+
+```javascript
+_.swapCase('hELLO')
+=> 'Hello'
+```
+
 **includes** _.includes(string, substring)
 
 Tests if string contains a substring.

--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -1,4 +1,4 @@
-// Underscore.string
+﻿// Underscore.string
 // (c) 2010 Esa-Matti Suuronen <esa-matti aet suuronen dot org>
 // Underscore.strings is freely distributable under the terms of the MIT license.
 // Documentation: https://github.com/epeli/underscore.string
@@ -234,6 +234,13 @@
       return (''+str).split('');
     },
 
+    swapCase: function(str) {
+      var swaped = [] , chs = _s.chars(str+'');
+      for(var i = 0 ; i<chs.length ; ++i)
+        swaped[i] = chs[i].toUpperCase() == chs[i] ? chs[i].toLowerCase() : chs[i].toUpperCase();
+      return swaped.join('');
+    },
+	
     escapeHTML: function(str) {
       return replace(str, /[&<>"']/g, function(match){ return '&' + reversedEscapeChars[match] + ';'; });
     },

--- a/test/strings.js
+++ b/test/strings.js
@@ -326,6 +326,10 @@ $(document).ready(function() {
     equals(_("Hello").chars().length, 5);
     equals(_(123).chars().length, 3);
   });
+  
+  test('String: swapCase', function(){
+	equals(_("hELLO").swapCase(), "Hello");	
+  });
 
   test('String: lines', function() {
     equals(_("Hello\nWorld").lines().length, 2);


### PR DESCRIPTION
[In Python we have ](http://docs.python.org/library/string.html#string.swapcase) swapcase function:

``` python
"hELLO".swapcase()  # => "Hello"
"abcABC".swapcase()  # => "ABCabc"
```

With this pull request I added an analogue to underscore.string.
