### PR TITLE
Fixed result type of the words function and tests

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -382,12 +382,12 @@ _('Hello').prune(10)
 => 'Hello'
 ```
 
-**words** _.words(str, delimiter=" ")
+**words** _.words(str, delimiter=/\s+/)
 
-Split string by delimiter (String or RegExp), ' ' by default.
+Split string by delimiter (String or RegExp), /\s+/ by default.
 
 ```javascript
-_.words("I love you")
+_.words("   I   love   you   ")
 => ["I","love","you"]
 
 _.words("I_love_you", "_")
@@ -395,6 +395,9 @@ _.words("I_love_you", "_")
 
 _.words("I-love-you", /-/)
 => ["I","love","you"]
+
+_.words("   ")
+=> []
 ```
 
 **sprintf** _.sprintf(string format, *arguments)
@@ -693,6 +696,7 @@ Otherwise changes will be rejected.
 *  Ed Finkler <coj@funkatron.com> (<http://funkatron.com>)
 *  Pavel Pravosud <rwz@duckroll.ru>
 *  Anton Lindqvist <anton@qvister.se> (<http://qvister.se>)
+*  Dmitry Karpunin <koderfunk@gmail.com> (<https://github.com/KODerFunk>)
 
 ## Licence ##
 

--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -28,9 +28,13 @@
 
   var slice = [].slice;
 
-  var defaultToWhiteSpace = function(characters){
+  var defaultToWhiteSpace = function(characters) {
     if (characters != null) {
-      return '[' + _s.escapeRegExp(characters) + ']';
+      if (Object.prototype.toString.call(characters) == '[object RegExp]') {
+        return characters.source;
+      } else {
+        return '[' + _s.escapeRegExp(characters) + ']';
+      }
     }
     return '\\s';
   };
@@ -378,8 +382,9 @@
     },
 
     words: function(str, delimiter) {
-      if (str == null || str == '') return '';
-      return _s.trim(str, delimiter).split(delimiter || /\s+/);
+      str = _s.trim(str, delimiter);
+      if (str == '') return [];
+      return str.split(delimiter || /\s+/);
     },
 
     pad: function(str, length, padStr, type) {

--- a/test/strings.js
+++ b/test/strings.js
@@ -11,7 +11,8 @@ $(document).ready(function() {
     equals(_('foo ').trim(), 'foo');
     equals(_(' foo ').trim(), 'foo');
     equals(_('    foo     ').trim(), 'foo');
-    equals(_('    foo     ', ' ').trim(), 'foo', 'Manually set whitespace');
+    equals(_('    foo     ').trim(' '), 'foo', 'Manually set whitespace');
+    equals(_('\t    foo \t  ').trim(/\s/), 'foo', 'Manually set RegExp /\\s+/');
 
     equals(_('ffoo').trim('f'), 'oo');
     equals(_('ooff').trim('f'), 'oo');
@@ -390,14 +391,16 @@ $(document).ready(function() {
   });
 
   test('String: words', function() {
-    equals(_('I love you!').words().length, 3);
-    equals(_(' I    love   you!  ').words().length, 3);
-    equals(_('I_love_you!').words('_').length, 3);
-    equals(_('I-love-you!').words(/-/).length, 3);
-    equals(_(123).words().length, 1);
-    equals(_('').words().length, 0);
-    equals(_(null).words().length, 0);
-    equals(_(undefined).words().length, 0);
+    deepEqual(_('I love you!').words(), ['I', 'love', 'you!']);
+    deepEqual(_(' I    love   you!  ').words(), ['I', 'love', 'you!']);
+    deepEqual(_('I_love_you!').words('_'), ['I', 'love', 'you!']);
+    deepEqual(_('I-love-you!').words(/-/), ['I', 'love', 'you!']);
+    deepEqual(_(123).words(), ['123'], '123 number has one word "123".');
+    deepEqual(_(0).words(), ['0'], 'Zero number has one word "0".');
+    deepEqual(_('').words(), [], 'Empty strings hasn\'t words.');
+    deepEqual(_('   ').words(), [], 'Clean strings hasn\'t words.');
+    deepEqual(_(null).words(), [], '"null" hasn\'t words.');
+    deepEqual(_(undefined).words(), [], '"undefined" hasn\'t words.');
   });
 
   test('String: chars', function() {


### PR DESCRIPTION
Fixed result type of the `words` function and fixed test coverage. 
`words(0)` should return an array with one word, `"0"`, as in the case of running `words(123)` we had `["123"]`, but we had an empty string `""`.
Also `words("")` returns `""`. But with clean string `words("    ")` return `[""]`. Magic)
Also fixed tests of `trim`.
