### PR TITLE
Added some Danish/Norwegian/Swedish characters to slugify

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -494,8 +494,8 @@
     slugify: function(str) {
       if (str == null) return '';
 
-      var from  = "ąàáäâãćęèéëêìíïîłńòóöôõùúüûñçżź",
-          to    = "aaaaaaceeeeeiiiilnooooouuuunczz",
+      var from  = "ąàáäâãåæćęèéëêìíïîłńòóöôõøùúüûñçżź",
+          to    = "aaaaaaaaceeeeeiiiilnoooooouuuunczz",
           regex = new RegExp(defaultToWhiteSpace(from), 'g');
 
       str = String(str).toLowerCase().replace(regex, function(c){


### PR DESCRIPTION
We have wrapped the slugify function to include åæø (aao) and thought that might be useful to others too.
