### PR TITLE
Implement count without split

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -208,6 +208,7 @@
       if (str == null || substr == null) return 0;
 
       str = String(str);
+      substr = String(substr);
       var n = 0;
       var pos = 0;
       var l = substr.length;


### PR DESCRIPTION
split creates an array that is (in this case) immediately thrown away. 
This produces unnecessary garbage and its (arguably) faster (see indexOf 1.2): 
http://jsperf.com/count-string-occurrence-in-string/10

The downside is that substr can no longer be a RegExp, but this was not
intended (at least according with the docs).
Also in the included test suite the new version is a bit slower than the previous one (about 30%)
but in that case only one string is tested and its very small.
