### PR TITLE
Fix for issue #165 escapeHTML/unescapeHTML does not support spaces

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -42,7 +42,8 @@
     gt: '>',
     quot: '"',
     amp: '&',
-    apos: "'"
+    apos: "'",
+    nbsp: ' '
   };
 
   var reversedEscapeChars = {};
@@ -239,7 +240,7 @@
 
     escapeHTML: function(str) {
       if (str == null) return '';
-      return String(str).replace(/[&<>"']/g, function(m){ return '&' + reversedEscapeChars[m] + ';'; });
+      return String(str).replace(/[&<>"'\x20]/g, function(m){ return '&' + reversedEscapeChars[m] + ';'; });
     },
 
     unescapeHTML: function(str) {


### PR DESCRIPTION
Minor modification that adds nbsp -> ' '  to the list of escaped characters, and added space to the escape characters regex.

Output examples:

escapeHTML('This is a test')
"This&nbsp;is&nbsp;a&nbsp;test"

unescapeHTML("This&nbsp;is&nbsp;a&nbsp;test")
"This is a test"
