### PR TITLE
update equals to equal in strings_standalone.js 

### DIFF
--- a/test/strings_standalone.js
+++ b/test/strings_standalone.js
@@ -7,6 +7,6 @@ $(document).ready(function() {
   });
 
   test("provides standalone functions", function() {
-    equals(typeof _.str.trim, "function");
+    equal(typeof _.str.trim, "function");
   });
 });


### PR DESCRIPTION
to eliminate the following error: QUnit.equals has been deprecated since 2009 (e88049a0), use QUnit.equal instead
