### PR TITLE
Added multi-term search function, with tests

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -608,7 +608,43 @@
         }
 
       return current.pop();
+    },
+    
+    /** 
+     * Does a multi-term (AND) search for a search string in 
+     * one or more sources.
+     * @param searchText can either be a string, in which case it will
+     * be split using .words(), or an array in which case it will be 
+     * used as-is. Each term must appear in at least one of the haystack
+     * strings (but not necessarily the same one).
+     * @param sources can be a string or an array of strings.
+     * @author github.com/gregmac
+     */
+    search: function (searchText, haystack) {
+        if (!_.isArray(haystack)) {
+            haystack = [haystack];
+        }
+        if (searchText == null) return false;
+        if (!_.isArray(searchText)) {
+            searchText = _s.words(searchText);
+        }
+        
+        if (searchText.length == 0) return false;
+        if (haystack.length == 0) return false;
+        
+        // all search words:
+        var result = _.every(searchText, function (searchWord) {
+            if (searchWord == null || searchWord == '') return false;
+            // must appear in at least one haystack element:
+            return _.some(haystack, function (sourceString) {
+                if (sourceString == null) return false;
+                return _s.contains(sourceString, searchWord);
+            });
+        });
+        console.log('Search for ', searchText, ' in ', haystack, ' = ', result);
+        return result;
     }
+
   };
 
   // Aliases

--- a/test/strings.js
+++ b/test/strings.js
@@ -644,5 +644,39 @@ $(document).ready(function() {
     equal(_.repeat(null, 2), '');
     equal(_.repeat(undefined, 2), '');
   });
+  
+  
+  test('String: search', function() {
+    equal(_.search('foo','match foo this'), true);
+    equal(_.search('foo','match bar this'), false);
+    equal(_.search('foo bar','match foo this'), false);
+    equal(_.search('foo bar','match foo this bar'), true);
+    equal(_.search(['foo','bar'],'match foo this bar'), true);
+    equal(_.search(['foo bar'],'match foo this bar'), false);
+    equal(_.search(['foo bar'],'match foo bar this'), true, 'Array search words should match exactly');
+    
+    equal(_.search(['foo bar','match foo'],'match foo bar this'), true);
+    equal(_.search(['foo bar','no match here'],'no match foo bar here'), false);
+    
+    equal(_.search('foo bar',['here is foo','here is bar']), true);
+    equal(_.search(['is foo','bar'],['here is foo','here is bar']), true);
+    
+    equal(_.search('','empty search string'), false, 'empty search string never matches');
+    equal(_.search([''],'empty'), false, 'empty search never matches');
+    equal(_.search([],'empty'), false, 'empty search never matches');
+    equal(_.search(null,'empty'), false, 'null search never matches');
+    equal(_.search([null],'empty'), false, 'null search never matches');
+    equal(_.search(['',null],'empty'), false, 'empty/null search never matches');
+    
+    equal(_.search('search',null), false, 'null haystack');
+    equal(_.search('search',[null]), false, 'null array haystack');
+    equal(_.search('search',[]), false, 'empty haystack');
+    
+    equal(_.search('1',[null,'1',null]), true, 'ok for haystack to have nulls as long as criteria is met');
+    equal(_.search('1',[null,'2',null]), false);
+    
+    equal(_.search([null,'1'],[null,'1',null]), false);
+    equal(_.search([null,'1'],[null,'2',null]), false);
+  });
 
 });


### PR DESCRIPTION
Multi-term (AND) search of one or more source strings. 

I'm using it in a single-page app to allow the user to filter a number of objects (representing websites) by the text they enter, searching in multiple properties of the objects (URL and site name).  This allows the user to enter, for example, "test1 widget" and find the object {url:'test1.w-co.net',name:'Widget Inc - Test Site 1'}. 

eg: Successful searches:

```
_.search('foo bar','match foo this bar')
_.search('foo bar',['here is foo','here is bar'])
```

Note, I have a dependency on underscorejs, specifically, this uses _.isArray, _.every, and _.some. I just use them, so it will fail if underscorejs isn't loaded. Is there a better/desired way to handle this?

Possible Todo's:
- Add a case-insensitive option.  In my use now, I just call .toLowerCase() before passing.
