### PR TITLE
Set seperator to null if one of the two string pass to the join fonction...

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -296,7 +296,7 @@
       var args = slice.call(arguments),
         separator = args.shift();
 
-      if (separator == null || args[0] == '' || args[1] == 1) separator = '';
+      if (separator == null || args[0] == '' || args[1] == '') separator = '';
 
       return args.join(separator);
     },


### PR DESCRIPTION
This update avoid some problem like : 

``` javaScript
_.join("--", "", "string");
--> --string
```
