### PR TITLE
Adding a hash method to underscore.string.js

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -636,7 +636,7 @@
       str = _s.trim(str);
       if (boolMatch(str, trueValues || ["true", "1"])) return true;
       if (boolMatch(str, falseValues || ["false", "0"])) return false;
-    }
+    },
     
     hash: function (str) {
       var hash = 0, len = str.length


### PR DESCRIPTION
# A hash method for underscore.string.js

I needed a string-to-hash method for my current project to create keys for strings and to add a simple password check without transferring the password as plain text to the server. I think this hash method for strings fits perfectly with underscore.string - actually, I was a bit surprised that it did not exist already, neither here nor in underscore.js.
# About the added method:

`_s.hash(str)` returns a number unique for the given string. The method is the same as implemented in Java and thus a kind of standard. It can be used for creating IDs; avoiding plain text when checking or transferring passwords or for caching. The implementation has been chosen according to http://jsperf.com/hashing-strings/22 (the one with the highest performance on the majority of browsers).
