### PR TITLE
.slugify: added optional second argument for customisable separator

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -520,8 +520,12 @@
       return _s.toSentence.apply(_s, args);
     },
 
-    slugify: function(str) {
+    slugify: function(str, separator) {
       if (str == null) return '';
+
+      if (separator == null) {
+        separator = '-';
+      }
 
       var from  = "ąàáäâãåæăćęèéëêìíïîłńòóöôõøśșțùúüûñçżź",
           to    = "aaaaaaaaaceeeeeiiiilnoooooosstuuuunczz",
@@ -529,10 +533,11 @@
 
       str = String(str).toLowerCase().replace(regex, function(c){
         var index = from.indexOf(c);
-        return to.charAt(index) || '-';
+        return to.charAt(index) || separator;
       });
 
-      return _s.dasherize(str.replace(/[^\w\s-]/g, ''));
+      return _s.trim(str.replace(/[^\w\s-]/g, '')).replace(/([A-Z])/g, '-$1').replace(/[-_\s]+/g, separator).toLowerCase();
+
     },
 
     surround: function(str, wrapper) {

--- a/test/strings.js
+++ b/test/strings.js
@@ -610,6 +610,7 @@ $(document).ready(function() {
     equal(_('').slugify(), '');
     equal(_(null).slugify(), '');
     equal(_(undefined).slugify(), '');
+    equal(_('Jack & Jill like numbers 1,2,3 and 4 and silly characters ?%.$!/').slugify('_'), 'jack_jill_like_numbers_123_and_4_and_silly_characters');
   });
 
   test('Strings: quote', function(){


### PR DESCRIPTION
hey,
needed a slug with underscores instead of dashes as a separator in one of my projects.
added a second optional argument to .slugify to make it more customisable.

realising the call that replaces .dasherize looks very ugly and is not perfect. as soon as i get some feedack on whether you agree on the customisability of .slugify, i'd suggest writing an equally customisable .dasherize (would need a good name for that ;)

what do you think?
