### PR TITLE
“./lib/underscore.string” → “./lib/underscore.string.js”

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "underscore",
     "string"
   ],
-  "main": "./lib/underscore.string",
+  "main": "./lib/underscore.string.js",
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
Fix epeli/underscore.string#254.
