### PR TITLE
Fix broken NPM install link

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
         <li><a href="dist/underscore.string.min.js">Production Version</a> (2.3.0) 9kb, Packed and Gzipped</li>
       </ul>
       <p>
-      You can also install the Underscore.string <a href="http://search.npmjs.org/#/underscore.string">NPM package</a>
+      You can also install the Underscore.string <a href="https://www.npmjs.org/package/underscore.string">NPM package</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
The current link to install from NPM is broken. Setting it to the correct link.
