### PR TITLE
#178 - numberFormat should accept numeric string

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -467,7 +467,7 @@
     numberFormat : function(number, dec, dsep, tsep) {
       if (isNaN(number) || number == null) return '';
 
-      number = number.toFixed(~~dec);
+      number = parseNumber(number).toFixed(~~dec);
       tsep = typeof tsep == 'string' ? tsep : ',';
 
       var parts = number.split('.'), fnums = parts[0],


### PR DESCRIPTION
numberFormat accepts a numeric string, but fails on toFixed. This change makes sure we are dealing with a number before calling .toFixed()
