### PR TITLE
Update classify method to use underscored instead of camelize

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -349,7 +349,7 @@
     },
 
     classify: function(str){
-      return _s.capitalize(_s.camelize(String(str).replace(/[\W_]/g, ' ')).replace(/\s/g, ''));
+      return _s.titleize(_s.underscored(String(str)).replace(/[\W_]/g, ' ')).replace(/\s/g, '');
     },
 
     humanize: function(str){


### PR DESCRIPTION
I had issues with the current implementation of capitalize and my work around for this issue before was to use underscored and then classify so I think this actually covers my issue with:

classify('DatePicker') return 'Datepicker'
