### PR TITLE
to work with grunt+wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "underscore",
     "string"
   ],
-  "main": "./lib/underscore.string.js",
+  "main": "lib/underscore.string.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/epeli/underscore.string.git"


### PR DESCRIPTION
I'm having problems with underscore.string when the grunt+wiredep try to inject the dependency in **<!-- bower:js -->**. 

I'm receiving this message:

``` bash
underscore.string was not injected in your file.
Please go take a look in "/home/marcelo/development/workspace_js/wasp-admin/bower_components/underscore.string" for the file you need, then manually include it in your file.
```

Changing the main property in .bower.json installed by "bower install", all works fine and wiredep inject the **bower_components/underscore.string/lib/underscore.string.js** in my index.html.

I don't know if the .bower.json downloaded by bower have the same configuration of bower.json file in the github repo. But, here is my pull request. 
