### PR TITLE
Strict option to fix #174.

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -550,11 +550,15 @@
       else return str;
     },
 
-    exports: function() {
+    exports: function(options) {
       var result = {};
+      var opts = options || {};
+      var regex = opts.strict ?
+        /^(?:include|contains|reverse|join)$/ :
+        /^(?:include|contains|reverse)$/;
 
       for (var prop in this) {
-        if (!this.hasOwnProperty(prop) || prop.match(/^(?:include|contains|reverse)$/)) continue;
+        if (!this.hasOwnProperty(prop) || prop.match(regex)) continue;
         result[prop] = this[prop];
       }
 

--- a/test/strings.js
+++ b/test/strings.js
@@ -5,6 +5,11 @@ $(document).ready(function() {
 
   module('String extensions');
 
+  test('Strings: exports', function() {
+    equal(_.has(_.str.exports(), 'join'), true);
+    equal(_.has(_.str.exports({ strict: true }), 'join'), false);
+  });
+
   test('Strings: naturalSort', function() {
     var arr =  ['foo2', 'foo1', 'foo10', 'foo30', 'foo100', 'foo10bar'],
       sorted = ['foo1', 'foo2', 'foo10', 'foo10bar', 'foo30', 'foo100'];


### PR DESCRIPTION
This is a backwards-compatible fix for #174 that would probably be preferable over #320. It requires passing options to, `exports({ strict: true })` to ensure no conflicting methods get added to `lodash` / `underscore`.

I think this seems like a good way of handling things, and the `strict` option could be documented such that it will always maintain compatibility with any enhancements added to `lodash` / `underscore`. For instance, if `count` was added to either, `underscore.string` would be updated to not export it (possibly causing some applications to require updates).
