### PR TITLE
Make capitalize lowercase rest of the string

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -56,6 +56,11 @@
     }
   }
 
+  // Helper for classify and humanize
+  function capitalizeFirst(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+
   var escapeChars = {
     lt: '<',
     gt: '>',
@@ -205,7 +210,7 @@
 
     capitalize : function(str){
       str = makeString(str);
-      return str.charAt(0).toUpperCase() + str.slice(1);
+      return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
     },
 
     chop: function(str, step){
@@ -338,11 +343,11 @@
     },
 
     classify: function(str){
-      return _s.capitalize(_s.camelize(String(str).replace(/[\W_]/g, ' ')).replace(/\s/g, ''));
+      return capitalizeFirst(_s.camelize(String(str).replace(/[\W_]/g, ' ')).replace(/\s/g, ''));
     },
 
     humanize: function(str){
-      return _s.capitalize(_s.underscored(str).replace(/_id$/,'').replace(/_/g, ' '));
+      return capitalizeFirst(_s.underscored(str).replace(/_id$/,'').replace(/_/g, ' '));
     },
 
     trim: function(str, characters){

--- a/test/strings.js
+++ b/test/strings.js
@@ -125,7 +125,7 @@ $(document).ready(function() {
   test('Strings: capitalize', function() {
     equal(_('fabio').capitalize(), 'Fabio', 'First letter is upper case');
     equal(_.capitalize('fabio'), 'Fabio', 'First letter is upper case');
-    equal(_.capitalize('FOO'), 'FOO', 'Other letters unchanged');
+    equal(_.capitalize('FOO BAR'), 'Foo bar', 'First letter is upper case, all other are in lower case');
     equal(_(123).capitalize(), '123', 'Non string');
     equal(_.capitalize(''), '', 'Capitalizing empty string returns empty string');
     equal(_.capitalize(null), '', 'Capitalizing null returns empty string');


### PR DESCRIPTION
It was unexpected, that `.capitalize` doesn't lowercase rest of the word. Checked in Ruby, Python, and Clojure - all have the same semantic - rest of the word is lowercased:

```
[1] pry(main)> "MiXeD cAsE".capitalize
=> "Mixed case"

>>> "MiXeD cAsE".capitalize()
'Mixed case'

user=> (clojure.string/capitalize "MiXeD cAsE")
"Mixed case"
```

Would be cool to have consistent with other behavior in `underscore.string`.
