### PR TITLE
improve tests, prevent errors in toSentence([]) and unquote(null)

### DIFF
--- a/tests/camelize.js
+++ b/tests/camelize.js
@@ -3,29 +3,32 @@ var camelize = require('../camelize');
 
 
 test('#camelize', function(){
+  // without decapitalizing of the first letter
   equal(camelize('the_camelize_string_method'), 'theCamelizeStringMethod');
   equal(camelize('webkit-transform'), 'webkitTransform');
   equal(camelize('-the-camelize-string-method'), 'TheCamelizeStringMethod');
   equal(camelize('_the_camelize_string_method'), 'TheCamelizeStringMethod');
   equal(camelize('The-camelize-string-method'), 'TheCamelizeStringMethod');
   equal(camelize('the camelize string method'), 'theCamelizeStringMethod');
-  equal(camelize(' the camelize  string method'), 'theCamelizeStringMethod');
-  equal(camelize('the camelize   string method'), 'theCamelizeStringMethod');
+  equal(camelize('The Camelize String Method'), 'TheCamelizeStringMethod');
   equal(camelize(' with   spaces'), 'withSpaces');
+  equal(camelize(' With   Spaces'), 'WithSpaces');
   equal(camelize("_som eWeird---name-"), 'SomEWeirdName');
   equal(camelize(''), '', 'Camelize empty string returns empty string');
   equal(camelize(null), '', 'Camelize null returns empty string');
   equal(camelize(undefined), '', 'Camelize undefined returns empty string');
   equal(camelize(123), '123');
+
+  // with decapitalizing of the first letter
   equal(camelize('the_camelize_string_method', true), 'theCamelizeStringMethod');
   equal(camelize('webkit-transform', true), 'webkitTransform');
   equal(camelize('-the-camelize-string-method', true), 'theCamelizeStringMethod');
   equal(camelize('_the_camelize_string_method', true), 'theCamelizeStringMethod');
   equal(camelize('The-camelize-string-method', true), 'theCamelizeStringMethod');
   equal(camelize('the camelize string method', true), 'theCamelizeStringMethod');
-  equal(camelize(' the camelize  string method', true), 'theCamelizeStringMethod');
-  equal(camelize('the camelize   string method', true), 'theCamelizeStringMethod');
+  equal(camelize('The Camelize String Method', true), 'theCamelizeStringMethod');
   equal(camelize(' with   spaces', true), 'withSpaces');
+  equal(camelize(' With   Spaces', true), 'withSpaces');
   equal(camelize("_som eWeird---name-", true), 'somEWeirdName');
   equal(camelize('', true), '', 'Camelize empty string returns empty string');
   equal(camelize(null, true), '', 'Camelize null returns empty string');

--- a/tests/capitalize.js
+++ b/tests/capitalize.js
@@ -4,7 +4,6 @@ var capitalize = require('../capitalize');
 
 test('#capitalize', function() {
   equal(capitalize('fabio'), 'Fabio', 'First letter is upper case');
-  equal(capitalize('fabio'), 'Fabio', 'First letter is upper case');
   equal(capitalize('FOO'), 'FOO', 'Other letters unchanged');
   equal(capitalize('FOO', false), 'FOO', 'Other letters unchanged');
   equal(capitalize('foO', false), 'FoO', 'Other letters unchanged');

--- a/tests/chop.js
+++ b/tests/chop.js
@@ -7,6 +7,6 @@ test('#chop', function(){
   ok(chop('whitespace', 2).length === 5, 'output [wh, it, es, pa, ce]');
   ok(chop('whitespace', 3).length === 4, 'output [whi, tes, pac, e]');
   ok(chop('whitespace')[0].length === 10, 'output [whitespace]');
-  ok(chop(12345, 1).length === 5, 'output [1, 2, 3,  4, 5]');
+  ok(chop(12345, 1).length === 5, 'output [1, 2, 3, 4, 5]');
 });
 

--- a/tests/escapeRegExp.js
+++ b/tests/escapeRegExp.js
@@ -5,5 +5,7 @@ var escapeRegExp = require('../helper/escapeRegExp');
 test('#escapeRegExp', function(){
   equal(escapeRegExp(/hello(?=\sworld)/.source), 'hello\\(\\?\\=\\\\sworld\\)', 'with lookahead');
   equal(escapeRegExp(/hello(?!\shell)/.source), 'hello\\(\\?\\!\\\\shell\\)', 'with negative lookahead');
+  equal(escapeRegExp(null), '', 'escaping null returns empty string');
+  equal(escapeRegExp(undefined), '', 'escaping undefined returns empty string');
 });
 

--- a/tests/lpad.js
+++ b/tests/lpad.js
@@ -7,6 +7,7 @@ test('#lpad', function() {
   equal(lpad(1, 8), '       1');
   equal(lpad('1', 8, '0'), '00000001');
   equal(lpad('1', 8, '0', 'left'), '00000001');
+  equal(lpad('abc', 1), 'abc', 'lpad with length shorter than string');
   equal(lpad('', 2), '  ');
   equal(lpad(null, 2), '  ');
   equal(lpad(undefined, 2), '  ');

--- a/tests/lrpad.js
+++ b/tests/lrpad.js
@@ -9,6 +9,7 @@ test('#lrpad', function() {
   equal(lrpad('foo', 8, '0'), '000foo00');
   equal(lrpad('foo', 7, '0'), '00foo00');
   equal(lrpad('foo', 7, '!@$%dofjrofj'), '!!foo!!');
+  equal(lrpad('abc', 1), 'abc', 'lrpad with length shorter than string');
   equal(lrpad('', 2), '  ');
   equal(lrpad(null, 2), '  ');
   equal(lrpad(undefined, 2), '  ');

--- a/tests/naturalCmp.js
+++ b/tests/naturalCmp.js
@@ -6,6 +6,8 @@ test("#naturalCmp", function() {
   // Should be associative
   _.each([
     ['abc', null],
+    ['abc', undefined],
+    ['abc', ''],
     ['abc', '123'],
     ['def', 'abc'],
     ['ab', 'a'],
@@ -21,7 +23,8 @@ test("#naturalCmp", function() {
     ['15ab16', '15ab'],
     ['abc', 'Abc'],
     ['abc', 'aBc'],
-    ['aBc', 'Abc']
+    ['aBc', 'Abc'],
+    [10, 2]
   ], function(vals) {
     var a = vals[0], b = vals[1];
     equal(naturalCmp(a, b), 1, '\'' + a + '\' >= \'' + b + '\'');
@@ -31,7 +34,10 @@ test("#naturalCmp", function() {
     ['123', '123'],
     ['abc', 'abc'],
     ['r12', 'r12'],
-    ['12a', '12a']
+    ['12a', '12a'],
+    ['', ''],
+    [undefined, undefined],
+    [null, null]
   ], function(vals) {
     var a = vals[0], b = vals[1];
     equal(naturalCmp(a, b), 0, '\'' + a + '\' == \'' + b + '\'');

--- a/tests/pad.js
+++ b/tests/pad.js
@@ -12,6 +12,7 @@ test('#pad', function() {
   equal(pad('foo', 8, '0', 'both'), '000foo00');
   equal(pad('foo', 7, '0', 'both'), '00foo00');
   equal(pad('foo', 7, '!@$%dofjrofj', 'both'), '!!foo!!');
+  equal(pad('abc', 1), 'abc');
   equal(pad('', 2), '  ');
   equal(pad(null, 2), '  ');
   equal(pad(undefined, 2), '  ');

--- a/tests/repeat.js
+++ b/tests/repeat.js
@@ -7,6 +7,8 @@ test('#repeat', function() {
   equal(repeat('foo', 3), 'foofoofoo');
   equal(repeat('foo', '3'), 'foofoofoo');
   equal(repeat(123, 2), '123123');
+  equal(repeat(1234, 0, '*'), '');
+  equal(repeat(1234, 1, '*'), '1234');
   equal(repeat(1234, 2, '*'), '1234*1234');
   equal(repeat(1234, 2, 5), '123451234');
   equal(repeat('', 2), '');

--- a/tests/rpad.js
+++ b/tests/rpad.js
@@ -7,6 +7,7 @@ test('#rpad', function() {
   equal(rpad(1, 8), '1       ');
   equal(rpad('1', 8, '0'), '10000000');
   equal(rpad('foo', 8, '0'), 'foo00000');
+  equal(rpad('foo', 1), 'foo', 'rpad with length shorter than string');
   equal(rpad('foo', 7, '0'), 'foo0000');
   equal(rpad('', 2), '  ');
   equal(rpad(null, 2), '  ');

--- a/tests/splice.js
+++ b/tests/splice.js
@@ -6,5 +6,10 @@ test('#splice', function(){
   equal(splice('https://edtsech@bitbucket.org/edtsech/underscore.strings', 30, 7, 'epeli'),
          'https://edtsech@bitbucket.org/epeli/underscore.strings');
   equal(splice(12345, 1, 2, 321), '132145', 'Non strings');
+  equal(splice('string', 0, 1), 'tring', 'splice with no substring')
+  equal(splice(null, 0, 1, 'substring'), 'substring', 'splice on null')
+  equal(splice(null, 0, 1), '', 'splice on null with no substring')
+  equal(splice(undefined, 0, 1, 'substring'), 'substring', 'splice on undefined')
+  equal(splice(undefined, 0, 1), '', 'splice on undefined with no substring')
 });
 

--- a/tests/surround.js
+++ b/tests/surround.js
@@ -9,6 +9,7 @@ test('#surround', function(){
   equal(surround('foo', 1), '1foo1');
   equal(surround('', 1), '11');
   equal(surround(null, 1), '11');
+  equal(surround(undefined, 1), '11');
   equal(surround('foo', ''), 'foo');
   equal(surround('foo', null), 'foo');
 });

--- a/tests/toBoolean.js
+++ b/tests/toBoolean.js
@@ -3,10 +3,8 @@ var toBoolean = require('../toBoolean');
 
 test('#toBoolean', function() {
   strictEqual(toBoolean("false"), false);
-  strictEqual(toBoolean("false"), false);
   strictEqual(toBoolean("False"), false);
   strictEqual(toBoolean("Falsy",null,["false", "falsy"]), false);
-  strictEqual(toBoolean("true"), true);
   strictEqual(toBoolean("the truth", "the truth", "this is falsy"), true);
   strictEqual(toBoolean("this is falsy", "the truth", "this is falsy"), false);
   strictEqual(toBoolean("true"), true);
@@ -25,5 +23,9 @@ test('#toBoolean', function() {
   strictEqual(toBoolean("foo true bar", /true/), true);
   strictEqual(toBoolean("foo FALSE bar", null, /FALSE/), false);
   strictEqual(toBoolean(" true  "), true);
+  strictEqual(toBoolean(true), true);
+  strictEqual(toBoolean(false), false);
+  strictEqual(toBoolean(null), false);
+  strictEqual(toBoolean(undefined), false);
 });
 

--- a/tests/toSentence.js
+++ b/tests/toSentence.js
@@ -1,12 +1,20 @@
 var equal = require('assert').equal;
 var toSentence = require('../toSentence');
 
-
 test('#toSentence', function() {
   equal(toSentence(['jQuery']), 'jQuery', 'array with a single element');
   equal(toSentence(['jQuery', 'MooTools']), 'jQuery and MooTools', 'array with two elements');
   equal(toSentence(['jQuery', 'MooTools', 'Prototype']), 'jQuery, MooTools and Prototype', 'array with three elements');
   equal(toSentence(['jQuery', 'MooTools', 'Prototype', 'YUI']), 'jQuery, MooTools, Prototype and YUI', 'array with multiple elements');
   equal(toSentence(['jQuery', 'MooTools', 'Prototype'], ',', ' or '), 'jQuery,MooTools or Prototype', 'handles custom separators');
+  equal(toSentence(['jQuery', 'MooTools', 'Prototype'], ',', ' or ', true), 'jQuery,MooTools, or Prototype', 'with serial flag true');
+  equal(toSentence([]), '', 'empty array');
+  equal(toSentence([null, undefined]), '', 'array with null and undefined');
+  equal(toSentence(['jQuery', null, undefined]), 'jQuery', 'array with null and undefined at the end');
+  equal(toSentence(['jQuery', null, undefined, 'MooTools']), 'jQuery and MooTools', 'array with null and undefined in the middle');
+  equal(toSentence(['']), '', 'array with single empty element');
+  equal(toSentence(['', '']), '', 'array with two empty elements');
+  equal(toSentence(['jQuery', '']), 'jQuery', 'array with empty element at the end');
+  equal(toSentence(['jQuery', '', 'MooTools']), 'jQuery and MooTools', 'array with empty element in the middle');
 });
 

--- a/tests/unquote.js
+++ b/tests/unquote.js
@@ -1,11 +1,13 @@
 var equal = require('assert').equal;
 var unquote = require('../unquote');
 
-
 test('#unquote', function(){
   equal(unquote('"foo"'), 'foo');
   equal(unquote('""foo""'), '"foo"');
   equal(unquote('"1"'), '1');
   equal(unquote("'foo'", "'"), 'foo');
+  equal(unquote(''), '', 'unquote empty string');
+  equal(unquote(null), '', 'unquote null');
+  equal(unquote(undefined), '', 'unqote undefined');
 });
 

--- a/toSentence.js
+++ b/toSentence.js
@@ -1,6 +1,16 @@
 var rtrim = require('./rtrim');
 
 module.exports = function toSentence(array, separator, lastSeparator, serial) {
+  // remove empty elements from array
+  array = array.filter(function(item) {
+    return item != '' && item != undefined && item != null
+  });
+
+  // fail early if array is empty
+  if (array.length == 0) {
+    return '';
+  }
+
   separator = separator || ', ';
   lastSeparator = lastSeparator || ' and ';
   var a = array.slice(),

--- a/unquote.js
+++ b/unquote.js
@@ -1,4 +1,7 @@
+var makeString = require('./helper/makeString');
+
 module.exports = function unquote(str, quoteChar) {
+  str = makeString(str);
   quoteChar = quoteChar || '"';
   if (str[0] === quoteChar && str[str.length - 1] === quoteChar)
     return str.slice(1, str.length - 1);


### PR DESCRIPTION
### Functionality changes

toSentence
- Result of `toSentence([])` is `""` (previously it rised an error).
- Empty strings, null and undefined in array are ommited
  ... so `toSentence([null, 'test', undefined])` will return 'test' (previously it was "null, test and undefined")

unquote
- Result of `unqote(null)` is `""` (previously it rised an error).
### Test improvements

camelizeze
- add uppercase string cases to test decapitalization
- remove similar cases of string with spaces

capitalize
- remove duplicate assertion

chop
- _(formatting)_ remove space inside array

escapeRegExp
- add cases with null and undefined

lpad
- add case with length shorter than string

naturalCms
- add cases with numbers, empty strings, undefined and null

pad
- add case with length shorter than string

repeat
- add case with 0 and 1 repetitions

rpad
- add case with length shorter than string

splice
- add case with no substring
- add cases with null and undefined

toBoolean
- add cases with true, false, null and undefined

toSentence
- add cases with empty array, empty string, null and undefined

unquote
- add cases for empty string, null and undefined
