### PR TITLE
chore: remove a few files from the packaged npm release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,8 @@ tests
 bench
 coverage
 scripts
+.editorconfig
+.eslintignore
+.eslintrc
+.travis.yml
+bower.json


### PR DESCRIPTION
I noticed a few files in my node_modules folder that don't really need to be there. This probably saves a decent amount of network traffic and disk storage given the number of users this package has.